### PR TITLE
feat: clarify ffmpeg-python dependency

### DIFF
--- a/inference_realesrgan_video.py
+++ b/inference_realesrgan_video.py
@@ -6,6 +6,7 @@ import numpy as np
 import os
 import shutil
 import subprocess
+import sys
 import torch
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from basicsr.utils.download_util import load_file_from_url
@@ -18,9 +19,10 @@ from realesrgan.archs.srvgg_arch import SRVGGNetCompact
 try:
     import ffmpeg
 except ImportError:
-    import pip
-    pip.main(['install', '--user', 'ffmpeg-python'])
-    import ffmpeg
+    raise ImportError(
+        'ffmpeg-python is required. Install it with "pip install ffmpeg-python" '
+        'or run `subprocess.run([sys.executable, "-m", "pip", "install", "ffmpeg-python"])`.'
+    )
 
 
 def get_video_meta_info(video_path):


### PR DESCRIPTION
## Summary
- Prevent automatic ffmpeg-python installs in `inference_realesrgan_video.py`
- Raise informative ImportError with guidance on ffmpeg-python installation
- Add `sys` import to support manual installation instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'realesrgan'; ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689705eafe748321934e3e2539ef67cd