### PR TITLE
feat: expand video inference options

### DIFF
--- a/docs/anime_video_model.md
+++ b/docs/anime_video_model.md
@@ -50,6 +50,9 @@ Usage:
                          this issue, you can use multi-processing by setting this parameter. As long as it
                          does not exceed the CUDA memory
 --extract_frame_first    If you encounter ffmpeg error when using multi-processing, you can turn this option on.
+--model_path             [Option] Model path. Usually, you do not need to specify it.
+--alpha_upsampler        The upsampler for the alpha channels. Options: realesrgan | bicubic.
+--bf16                   Use bfloat16 precision during inference. Default: fp16 (half precision).
 ```
 
 ### NCNN Executable File

--- a/realesrgan/utils.py
+++ b/realesrgan/utils.py
@@ -23,7 +23,8 @@ class RealESRGANer():
             0 denotes for do not use tile. Default: 0.
         tile_pad (int): The pad size for each tile, to remove border artifacts. Default: 10.
         pre_pad (int): Pad the input images to avoid border artifacts. Default: 10.
-        half (float): Whether to use half precision during inference. Default: False.
+        half (bool): Whether to use half precision during inference. Default: False.
+        bf16 (bool): Whether to use bfloat16 precision during inference. Default: False.
     """
 
     def __init__(self,
@@ -35,6 +36,7 @@ class RealESRGANer():
                  tile_pad=10,
                  pre_pad=10,
                  half=False,
+                 bf16=False,
                  device=None,
                  gpu_id=None):
         self.scale = scale
@@ -43,6 +45,7 @@ class RealESRGANer():
         self.pre_pad = pre_pad
         self.mod_scale = None
         self.half = half
+        self.bf16 = bf16
 
         # initialize model
         if gpu_id:
@@ -73,6 +76,8 @@ class RealESRGANer():
         self.model = model.to(self.device)
         if self.half:
             self.model = self.model.half()
+        elif self.bf16:
+            self.model = self.model.to(torch.bfloat16)
 
     def dni(self, net_a, net_b, dni_weight, key='params', loc='cpu'):
         """Deep network interpolation.
@@ -92,6 +97,8 @@ class RealESRGANer():
         self.img = img.unsqueeze(0).to(self.device)
         if self.half:
             self.img = self.img.half()
+        elif self.bf16:
+            self.img = self.img.to(torch.bfloat16)
 
         # pre_pad
         if self.pre_pad != 0:


### PR DESCRIPTION
## Summary
- extend `inference_realesrgan_video.py` with custom model path, alpha upsampler, precision (fp16/bf16/fp32) and gpu-id flags
- enable bfloat16 support in `RealESRGANer`
- document new CLI options for anime video model inference

## Testing
- `pytest tests/test_utils.py` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6897060dbc508321a75a67c53f35887f