### PR TITLE
feat: auto tile sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Note that it may introduce block inconsistency (and also generate slightly diffe
 #### Usage of python script
 
 1. You can use X4 model for **arbitrary output size** with the argument `outscale`. The program will further perform cheap resize operation after the Real-ESRGAN output.
+2. If `--tile` is not specified, a tile size that fits the available VRAM will be automatically chosen. Specify `--tile` (or `--tile 0` to disable tiling) to override this behaviour.
 
 ```console
 Usage: python inference_realesrgan.py -n RealESRGAN_x4plus -i infile -o outfile [options]...
@@ -188,7 +189,7 @@ A common command: python inference_realesrgan.py -n RealESRGAN_x4plus -i infile 
   -n --model_name      Model name. Default: RealESRGAN_x4plus
   -s, --outscale       The final upsampling scale of the image. Default: 4
   --suffix             Suffix of the restored image. Default: out
-  -t, --tile           Tile size, 0 for no tile during testing. Default: 0
+  -t, --tile           Tile size. Automatically determined from free VRAM when not set. Use 0 to disable tiling
   --face_enhance       Whether to use GFPGAN to enhance face. Default: False
   --fp32               Use fp32 precision during inference. Default: fp16 (half precision).
   --ext                Image extension. Options: auto | jpg | png, auto means using the same extension as inputs. Default: auto

--- a/README_CN.md
+++ b/README_CN.md
@@ -227,6 +227,7 @@ python inference_realesrgan.py -n RealESRGAN_x4plus_anime_6B -i inputs
 ### Python 脚本的用法
 
 1. 虽然你使用了 X4 模型，但是你可以 **输出任意尺寸比例的图片**，只要实用了 `outscale` 参数. 程序会进一步对模型的输出图像进行缩放。
+2. 若未指定 `--tile`，程序会根据显存自动选择合适的分块大小。你也可以通过显式设置 `--tile`（或 `--tile 0` 以关闭分块）来覆盖此行为。
 
 ```console
 Usage: python inference_realesrgan.py -n RealESRGAN_x4plus -i infile -o outfile [options]...
@@ -239,7 +240,7 @@ A common command: python inference_realesrgan.py -n RealESRGAN_x4plus -i infile 
   -n --model_name      Model name. Default: RealESRGAN_x4plus
   -s, --outscale       The final upsampling scale of the image. Default: 4
   --suffix             Suffix of the restored image. Default: out
-  -t, --tile           Tile size, 0 for no tile during testing. Default: 0
+  -t, --tile           图像分块大小。默认根据可用显存自动确定，设置为0表示不分块
   --face_enhance       Whether to use GFPGAN to enhance face. Default: False
   --fp32               Whether to use half precision during inference. Default: False
   --ext                Image extension. Options: auto | jpg | png, auto means using the same extension as inputs. Default: auto

--- a/inference_realesrgan.py
+++ b/inference_realesrgan.py
@@ -1,11 +1,12 @@
 import argparse
 import cv2
 import glob
+import math
 import os
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from basicsr.utils.download_util import load_file_from_url
 
-from realesrgan import RealESRGANer
+from realesrgan import RealESRGANer, get_free_gpu_memory
 from realesrgan.archs.srvgg_arch import SRVGGNetCompact
 
 
@@ -33,7 +34,13 @@ def main():
     parser.add_argument(
         '--model_path', type=str, default=None, help='[Option] Model path. Usually, you do not need to specify it')
     parser.add_argument('--suffix', type=str, default='out', help='Suffix of the restored image')
-    parser.add_argument('-t', '--tile', type=int, default=0, help='Tile size, 0 for no tile during testing')
+    parser.add_argument(
+        '-t',
+        '--tile',
+        type=int,
+        default=None,
+        help=('Tile size. Automatically set to fit VRAM when not specified. '
+              'Use 0 to disable tiling'))
     parser.add_argument('--tile_pad', type=int, default=10, help='Tile padding')
     parser.add_argument('--pre_pad', type=int, default=0, help='Pre padding size at each border')
     parser.add_argument('--face_enhance', action='store_true', help='Use GFPGAN to enhance face')
@@ -109,7 +116,7 @@ def main():
         model_path=model_path,
         dni_weight=dni_weight,
         model=model,
-        tile=args.tile,
+        tile=0 if args.tile is None else args.tile,
         tile_pad=args.tile_pad,
         pre_pad=args.pre_pad,
         half=not args.fp32,
@@ -139,6 +146,15 @@ def main():
             img_mode = 'RGBA'
         else:
             img_mode = None
+
+        if args.tile is None:
+            h, w = img.shape[:2]
+            free_mem = get_free_gpu_memory(args.gpu_id)
+            bytes_per_pixel = (4 if args.fp32 else 2) * 3 * (netscale ** 2 + 1)
+            tile_size = int(math.sqrt(free_mem * 0.8 / bytes_per_pixel))
+            upsampler.tile_size = 0 if tile_size >= max(h, w) else tile_size
+        else:
+            upsampler.tile_size = args.tile
 
         try:
             if args.face_enhance:

--- a/inference_realesrgan_video.py
+++ b/inference_realesrgan_video.py
@@ -1,6 +1,7 @@
 import argparse
 import cv2
 import glob
+import math
 import mimetypes
 import numpy as np
 import os
@@ -12,7 +13,7 @@ from basicsr.utils.download_util import load_file_from_url
 from os import path as osp
 from tqdm import tqdm
 
-from realesrgan import RealESRGANer
+from realesrgan import RealESRGANer, get_free_gpu_memory
 from realesrgan.archs.srvgg_arch import SRVGGNetCompact
 
 try:
@@ -223,7 +224,7 @@ def inference_video(args, video_save_path, device=None, total_workers=1, worker_
         model_path=model_path,
         dni_weight=dni_weight,
         model=model,
-        tile=args.tile,
+        tile=0 if args.tile is None else args.tile,
         tile_pad=args.tile_pad,
         pre_pad=args.pre_pad,
         half=not args.fp32,
@@ -249,6 +250,13 @@ def inference_video(args, video_save_path, device=None, total_workers=1, worker_
     reader = Reader(args, total_workers, worker_idx)
     audio = reader.get_audio()
     height, width = reader.get_resolution()
+    if args.tile is None:
+        free_mem = get_free_gpu_memory(device.index if device else None)
+        bytes_per_pixel = (4 if args.fp32 else 2) * 3 * (netscale ** 2 + 1)
+        tile_size = int(math.sqrt(free_mem * 0.8 / bytes_per_pixel))
+        upsampler.tile_size = 0 if tile_size >= max(height, width) else tile_size
+    else:
+        upsampler.tile_size = args.tile
     fps = reader.get_fps()
     writer = Writer(args, audio, height, width, video_save_path, fps)
 
@@ -348,7 +356,13 @@ def main():
               'Only used for the realesr-general-x4v3 model'))
     parser.add_argument('-s', '--outscale', type=float, default=4, help='The final upsampling scale of the image')
     parser.add_argument('--suffix', type=str, default='out', help='Suffix of the restored video')
-    parser.add_argument('-t', '--tile', type=int, default=0, help='Tile size, 0 for no tile during testing')
+    parser.add_argument(
+        '-t',
+        '--tile',
+        type=int,
+        default=None,
+        help=('Tile size. Automatically set to fit VRAM when not specified. '
+              'Use 0 to disable tiling'))
     parser.add_argument('--tile_pad', type=int, default=10, help='Tile padding')
     parser.add_argument('--pre_pad', type=int, default=0, help='Pre padding size at each border')
     parser.add_argument('--face_enhance', action='store_true', help='Use GFPGAN to enhance face')

--- a/realesrgan/utils.py
+++ b/realesrgan/utils.py
@@ -11,6 +11,24 @@ from torch.nn import functional as F
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+def get_free_gpu_memory(gpu_id=None):
+    """Get the free GPU memory in bytes.
+
+    Args:
+        gpu_id (int, optional): GPU device id. If None, the current device is
+            used.
+
+    Returns:
+        int: Free memory on the specified GPU in bytes. Returns 0 if CUDA is
+        not available.
+    """
+    if not torch.cuda.is_available():
+        return 0
+    device = torch.cuda.current_device() if gpu_id is None else gpu_id
+    free_mem, _ = torch.cuda.mem_get_info(device)
+    return free_mem
+
+
 class RealESRGANer():
     """A helper class for upsampling images with RealESRGAN.
 


### PR DESCRIPTION
## Summary
- detect free GPU memory via torch.cuda.mem_get_info
- auto compute tile size when --tile is omitted, falling back to full-frame if possible
- document automatic tile behavior and manual override

## Testing
- `pre-commit run --files realesrgan/utils.py inference_realesrgan.py inference_realesrgan_video.py README.md README_CN.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest tests/test_utils.py` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `apt-get update` *(fails: 403  Forbidden)*
- `python -m py_compile realesrgan/utils.py inference_realesrgan.py inference_realesrgan_video.py`


------
https://chatgpt.com/codex/tasks/task_e_6897061366b08321bfd887b06263dee2