### PR TITLE
Simplify ffmpeg import and document ffmpeg dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Other recommended projects:<br>
     # facexlib and gfpgan are for face enhancement
     pip install facexlib
     pip install gfpgan
+    # Install ffmpeg and the Python binding (ffmpeg-python) beforehand
+    # e.g., on Ubuntu: sudo apt-get install ffmpeg
     pip install -r requirements.txt
     python setup.py develop
     ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -184,6 +184,8 @@ Usage: realesrgan-ncnn-vulkan.exe -i infile -o outfile [options]...
     # facexlib和gfpgan是用来增强人脸的
     pip install facexlib
     pip install gfpgan
+    # 预先安装 ffmpeg 及其 Python 绑定 (ffmpeg-python)
+    # 例如在 Ubuntu: sudo apt-get install ffmpeg
     pip install -r requirements.txt
     python setup.py develop
     ```

--- a/docs/anime_video_model.md
+++ b/docs/anime_video_model.md
@@ -32,6 +32,14 @@ The following are some demos (best view in the full screen mode).
 
 ### PyTorch Inference
 
+Before running the following commands, make sure that **ffmpeg** and the Python binding
+`ffmpeg-python` are installed on your system. On Ubuntu you can install them with:
+
+```bash
+sudo apt-get install ffmpeg
+pip install ffmpeg-python
+```
+
 ```bash
 # download model
 wget https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.5.0/realesr-animevideov3.pth -P weights

--- a/inference_realesrgan_video.py
+++ b/inference_realesrgan_video.py
@@ -15,12 +15,7 @@ from tqdm import tqdm
 from realesrgan import RealESRGANer
 from realesrgan.archs.srvgg_arch import SRVGGNetCompact
 
-try:
-    import ffmpeg
-except ImportError:
-    import pip
-    pip.main(['install', '--user', 'ffmpeg-python'])
-    import ffmpeg
+import ffmpeg
 
 
 def get_video_meta_info(video_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Pillow
 torch>=1.7
 torchvision
 tqdm
+ffmpeg-python>=0.2


### PR DESCRIPTION
## Summary
- drop runtime ffmpeg installation and import ffmpeg directly
- declare ffmpeg-python dependency
- document installing ffmpeg and ffmpeg-python for video inference

## Testing
- `pre-commit run --files inference_realesrgan_video.py requirements.txt README.md docs/anime_video_model.md`
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6897061ff3548321af573eace4ef61c0