### PR TITLE
Add automatic tile sizing based on available VRAM

### DIFF
--- a/inference_realesrgan_video.py
+++ b/inference_realesrgan_video.py
@@ -1,6 +1,7 @@
 import argparse
 import cv2
 import glob
+import math
 import mimetypes
 import numpy as np
 import os
@@ -52,6 +53,36 @@ def get_sub_video(args, num_process, process_idx):
     print(' '.join(cmd))
     subprocess.call(' '.join(cmd), shell=True)
     return out_path
+
+
+def auto_tile_size(h, w, scale, tile_pad, max_mem_ratio=0.9, fp32=False, device=None):
+    """Automatically derive a tile size that fits into available GPU memory.
+
+    Args:
+        h (int): input height.
+        w (int): input width.
+        scale (int): upsampling scale of the model.
+        tile_pad (int): padding used for each tile.
+        max_mem_ratio (float): fraction of free VRAM to use.
+        fp32 (bool): whether inference uses fp32 precision.
+        device (torch.device, optional): device to query memory information.
+    Returns:
+        int: tile size in pixels. 0 indicates that no tiling is required.
+    """
+    if not torch.cuda.is_available():
+        return 0
+    try:
+        dev = device if device is not None else torch.cuda.current_device()
+        free_mem, _ = torch.cuda.mem_get_info(dev)
+    except Exception:
+        return 0
+    max_mem = int(free_mem * max_mem_ratio)
+    bytes_per_elem = 4 if fp32 else 2
+    # rough estimation: input + output tensors
+    bytes_per_pixel = bytes_per_elem * 3 * (scale ** 2 + 1)
+    tile = int(math.sqrt(max_mem / bytes_per_pixel)) - 2 * tile_pad
+    tile = min(tile, h, w)
+    return max(tile, 0)
 
 
 class Reader:
@@ -217,6 +248,16 @@ def inference_video(args, video_save_path, device=None, total_workers=1, worker_
         model_path = [model_path, wdn_model_path]
         dni_weight = [args.denoise_strength, 1 - args.denoise_strength]
 
+    reader = Reader(args, total_workers, worker_idx)
+    height, width = reader.get_resolution()
+    fps = reader.get_fps()
+    audio = reader.get_audio()
+
+    if args.tile == 0:
+        args.tile = auto_tile_size(height, width, netscale, args.tile_pad, args.max_mem_ratio, args.fp32, device)
+        if args.tile:
+            print(f'Auto tile size: {args.tile}')
+
     # restorer
     upsampler = RealESRGANer(
         scale=netscale,
@@ -246,10 +287,6 @@ def inference_video(args, video_save_path, device=None, total_workers=1, worker_
     else:
         face_enhancer = None
 
-    reader = Reader(args, total_workers, worker_idx)
-    audio = reader.get_audio()
-    height, width = reader.get_resolution()
-    fps = reader.get_fps()
     writer = Writer(args, audio, height, width, video_save_path, fps)
 
     pbar = tqdm(total=len(reader), unit='frame', desc='inference')
@@ -351,6 +388,11 @@ def main():
     parser.add_argument('-t', '--tile', type=int, default=0, help='Tile size, 0 for no tile during testing')
     parser.add_argument('--tile_pad', type=int, default=10, help='Tile padding')
     parser.add_argument('--pre_pad', type=int, default=0, help='Pre padding size at each border')
+    parser.add_argument(
+        '--max_mem_ratio',
+        type=float,
+        default=0.9,
+        help='Upper bound of GPU memory usage for auto tile size computation')
     parser.add_argument('--face_enhance', action='store_true', help='Use GFPGAN to enhance face')
     parser.add_argument(
         '--fp32', action='store_true', help='Use fp32 precision during inference. Default: fp16 (half precision).')


### PR DESCRIPTION
## Summary
- add `auto_tile_size` helper to estimate max tile from `torch.cuda.mem_get_info`
- automatically compute tile size when `--tile` is 0
- add `--max_mem_ratio` flag to control how much VRAM to use

## Testing
- `python -m pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68970625a6c08321b394a5febe9d1438