### PR TITLE
Wrap video inference loop with inference mode and optional debug sync

### DIFF
--- a/inference_realesrgan_video.py
+++ b/inference_realesrgan_video.py
@@ -253,24 +253,26 @@ def inference_video(args, video_save_path, device=None, total_workers=1, worker_
     writer = Writer(args, audio, height, width, video_save_path, fps)
 
     pbar = tqdm(total=len(reader), unit='frame', desc='inference')
-    while True:
-        img = reader.get_frame()
-        if img is None:
-            break
+    with torch.inference_mode():
+        while True:
+            img = reader.get_frame()
+            if img is None:
+                break
 
-        try:
-            if args.face_enhance:
-                _, _, output = face_enhancer.enhance(img, has_aligned=False, only_center_face=False, paste_back=True)
+            try:
+                if args.face_enhance:
+                    _, _, output = face_enhancer.enhance(img, has_aligned=False, only_center_face=False, paste_back=True)
+                else:
+                    output, _ = upsampler.enhance(img, outscale=args.outscale)
+            except RuntimeError as error:
+                print('Error', error)
+                print('If you encounter CUDA out of memory, try to set --tile with a smaller number.')
             else:
-                output, _ = upsampler.enhance(img, outscale=args.outscale)
-        except RuntimeError as error:
-            print('Error', error)
-            print('If you encounter CUDA out of memory, try to set --tile with a smaller number.')
-        else:
-            writer.write_frame(output)
+                writer.write_frame(output)
 
-        torch.cuda.synchronize(device)
-        pbar.update(1)
+            if args.debug:
+                torch.cuda.synchronize(device)
+            pbar.update(1)
 
     reader.close()
     writer.close()
@@ -358,6 +360,7 @@ def main():
     parser.add_argument('--ffmpeg_bin', type=str, default='ffmpeg', help='The path to ffmpeg')
     parser.add_argument('--extract_frame_first', action='store_true')
     parser.add_argument('--num_process_per_gpu', type=int, default=1)
+    parser.add_argument('--debug', action='store_true', help='Enable explicit CUDA synchronization for debugging')
 
     parser.add_argument(
         '--alpha_upsampler',


### PR DESCRIPTION
## Summary
- Wrap video frame processing loop in `torch.inference_mode()` and rely on implicit synchronization.
- Remove unconditional `torch.cuda.synchronize` and add a `--debug` flag to re-enable it when needed.

## Testing
- `pre-commit run --files inference_realesrgan_video.py` *(command not found)*
- `pytest` *(errors: No module named 'realesrgan'; ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68970627a9bc8321832b1a8ca831043a