### PR TITLE
Use subprocess for FFmpeg operations in video inference

### DIFF
--- a/inference_realesrgan_video.py
+++ b/inference_realesrgan_video.py
@@ -283,7 +283,27 @@ def run(args):
     if args.extract_frame_first:
         tmp_frames_folder = osp.join(args.output, f'{args.video_name}_inp_tmp_frames')
         os.makedirs(tmp_frames_folder, exist_ok=True)
-        os.system(f'ffmpeg -i {args.input} -qscale:v 1 -qmin 1 -qmax 1 -vsync 0  {tmp_frames_folder}/frame%08d.png')
+        frame_pattern = osp.join(tmp_frames_folder, 'frame%08d.png')
+        try:
+            subprocess.run(
+                [
+                    'ffmpeg',
+                    '-i',
+                    args.input,
+                    '-qscale:v',
+                    '1',
+                    '-qmin',
+                    '1',
+                    '-qmax',
+                    '1',
+                    '-vsync',
+                    '0',
+                    frame_pattern,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError('FFmpeg failed to extract frames') from e
         args.input = tmp_frames_folder
 
     num_gpus = torch.cuda.device_count()
@@ -381,7 +401,13 @@ def main():
 
     if is_video and args.input.endswith('.flv'):
         mp4_path = args.input.replace('.flv', '.mp4')
-        os.system(f'ffmpeg -i {args.input} -codec copy {mp4_path}')
+        try:
+            subprocess.run(
+                ['ffmpeg', '-i', args.input, '-codec', 'copy', mp4_path],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError('FFmpeg failed to convert FLV to MP4') from e
         args.input = mp4_path
 
     if args.extract_frame_first and not is_video:


### PR DESCRIPTION
## Summary
- Replace os.system calls with subprocess.run for frame extraction and FLV-to-MP4 conversion
- Surface FFmpeg errors with explicit exceptions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'realesrgan'; ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897062a1f508321a052bf0a1fec4f80